### PR TITLE
[bug]Resolving the issue with the default implementation of hostNameV…

### DIFF
--- a/tosan-soap-client/src/main/java/com/tosan/client/soap/SoapRequestContext.java
+++ b/tosan-soap-client/src/main/java/com/tosan/client/soap/SoapRequestContext.java
@@ -8,6 +8,7 @@ import jakarta.xml.ws.WebServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
 /**
@@ -86,6 +87,8 @@ public class SoapRequestContext {
             String truststorePassword = config.getSsl().getTruststorePassword();
             String keystorePassword = config.getSsl().getKeystorePassword();
             String truststoreAlias = config.getSsl().getTruststoreAlias();
+            HttpsURLConnection.setDefaultHostnameVerifier((hostname, session)
+                    -> hostname.equals(session.getPeerHost()));
 
             try {
                 SSLSocketFactory socketFactory = new SSLSocketFactoryGenerator(sslContext,

--- a/tosan-soap-client/src/main/java/com/tosan/client/soap/connection/ConnectionVerifier.java
+++ b/tosan-soap-client/src/main/java/com/tosan/client/soap/connection/ConnectionVerifier.java
@@ -42,7 +42,8 @@ public class ConnectionVerifier {
         try {
             if (config.isInitialConnection()) {
                 if (serverUrl.getProtocol().equals("https")) {
-                    HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> hostname.equals(serverUrl.getHost()));
+                    HttpsURLConnection.setDefaultHostnameVerifier((hostname, session)
+                            -> hostname.equals(session.getPeerHost()));
                     testHttpsConnection(config, serverUrl);
                 } else {
                     testHttpConnection(config, serverUrl);


### PR DESCRIPTION
…erifier in SSL settings.

If this library is used to connect to two or more servers, the address of the last server is considered as the valid address in the hostNameVerifier implementation, instead of the address present in the session.