### PR TITLE
[feature]Integrate OpenTelemetry tracing into SOAP client via SOAPHan…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
                 <artifactId>commons-lang3</artifactId>
                 <version>3.14.0</version>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-api</artifactId>
+                <version>1.52.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/tosan-soap-client/pom.xml
+++ b/tosan-soap-client/pom.xml
@@ -40,5 +40,9 @@
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>jaxws-rt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/tosan-soap-client/src/main/java/com/tosan/client/soap/SoapServiceProvider.java
+++ b/tosan-soap-client/src/main/java/com/tosan/client/soap/SoapServiceProvider.java
@@ -1,6 +1,7 @@
 package com.tosan.client.soap;
 
 import com.tosan.client.soap.config.SoapServiceConfig;
+import io.opentelemetry.api.trace.Tracer;
 
 import java.net.URL;
 
@@ -14,9 +15,16 @@ import java.net.URL;
 public abstract class SoapServiceProvider<T, V extends SoapServiceConfig> {
     protected V config;
     private T service;
+    private final Tracer tracer;
 
     public SoapServiceProvider(V config) {
         this.config = config;
+        this.tracer = null;
+    }
+
+    public SoapServiceProvider(V config, Tracer tracer) {
+        this.config = config;
+        this.tracer = tracer;
     }
 
     /**
@@ -29,12 +37,14 @@ public abstract class SoapServiceProvider<T, V extends SoapServiceConfig> {
         if (service == null) {
             synchronized (this) {
                 if (service == null) {
-                    service = getServiceSoap(config);
+                    service = getServiceSoap(config, tracer);
                 }
             }
         }
         return service;
     }
+
+    protected abstract T getServiceSoap(V config, Tracer tracer);
 
     protected abstract T getServiceSoap(V config);
 

--- a/tosan-soap-client/src/main/java/com/tosan/client/soap/handler/MonitoringHandler.java
+++ b/tosan-soap-client/src/main/java/com/tosan/client/soap/handler/MonitoringHandler.java
@@ -1,0 +1,126 @@
+package com.tosan.client.soap.handler;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Scope;
+import jakarta.xml.soap.SOAPException;
+import jakarta.xml.soap.SOAPMessage;
+import jakarta.xml.ws.handler.MessageContext;
+import jakarta.xml.ws.handler.soap.SOAPHandler;
+import jakarta.xml.ws.handler.soap.SOAPMessageContext;
+
+import javax.xml.namespace.QName;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * @author a.ebrahimi
+ * @since 5/24/2014
+ */
+public class MonitoringHandler implements SOAPHandler<SOAPMessageContext> {
+    public static final String SOAP_REQUEST_PREFIX = "SOAP Request: ";
+    public static final String SOAP_OPERATION = "soap.operation";
+    public static final String OTEL_SPAN = "otel.span";
+    public static final String OTEL_SCOPE = "otel.scope";
+    private static final String ENDPOINT_KEY = "jakarta.xml.ws.service.endpoint.address";
+    public static final String URI = "http.url";
+    public static final String OUTCOME = "outcome";
+    public static final String ERROR = "ERROR";
+    public static final String CLIENT_NAME = "client.name";
+
+    private final Tracer tracer;
+    private final String clientName;
+
+    public MonitoringHandler(Tracer tracer, String clientName) {
+        this.tracer = tracer;
+        this.clientName = clientName;
+    }
+
+    @Override
+    public boolean handleMessage(SOAPMessageContext context) {
+        Boolean outbound = (Boolean) context.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
+        if (outbound) {
+            startSpan(context);
+        } else {
+            finishSpan(context);
+        }
+        return true;
+    }
+
+    private void startSpan(SOAPMessageContext context) {
+        QName operation = (QName) context.get(SOAPMessageContext.WSDL_OPERATION);
+        String operationName = operation != null ? operation.getLocalPart() : "Unknown";
+        Span span = tracer.spanBuilder(SOAP_REQUEST_PREFIX)
+                .setSpanKind(SpanKind.CLIENT)
+                .setParent(io.opentelemetry.context.Context.current())
+                .startSpan();
+        span.setAttribute(SOAP_OPERATION, operationName);
+        Scope scope = span.makeCurrent();
+        context.put(OTEL_SPAN, span);
+        context.put(OTEL_SCOPE, scope);
+        String uri = context.get(ENDPOINT_KEY).toString();
+        span.setAttribute(URI, uri);
+        String clientNameValue = clientName != null ? clientName : uri;
+        span.setAttribute(CLIENT_NAME, clientNameValue);
+    }
+
+    private void finishSpan(SOAPMessageContext context) {
+        Span span = (Span) context.get(OTEL_SPAN);
+        try (Scope scope = (Scope) context.get(OTEL_SCOPE)) {
+            SOAPMessage message = context.getMessage();
+            if (message != null && message.getSOAPBody().hasFault()) {
+                span.setAttribute(OUTCOME, ERROR);
+                span.setStatus(StatusCode.ERROR);
+            } else {
+                span.setAttribute(OUTCOME, "SUCCESS");
+                span.setStatus(StatusCode.OK);
+            }
+        } catch (SOAPException e) {
+            span.setAttribute(OUTCOME, ERROR);
+            span.setStatus(StatusCode.ERROR);
+        } finally {
+            span.end();
+        }
+    }
+
+    @Override
+    public void close(MessageContext context) {
+        Scope scope = (Scope) context.get(OTEL_SCOPE);
+        Span span = (Span) context.get(OTEL_SPAN);
+        if (span != null && span.getSpanContext().isValid() && span.isRecording()) {
+            span.setAttribute(OUTCOME, ERROR);
+            span.setStatus(StatusCode.ERROR);
+            span.end();
+        }
+        if (scope != null) {
+            scope.close();
+        }
+    }
+
+    @Override
+    public boolean handleFault(SOAPMessageContext context) {
+        Span span = (Span) context.get(OTEL_SPAN);
+        if (span != null) {
+            span.setAttribute(OUTCOME, ERROR);
+            try {
+                span.recordException(new RuntimeException(context.getMessage().getSOAPBody().getFault().getFaultCode()));
+            } catch (SOAPException e) {
+                throw new RuntimeException("UnknownFaultCode");
+            }
+            span.setStatus(io.opentelemetry.api.trace.StatusCode.ERROR);
+            span.end();
+        }
+        Scope scope = (Scope) context.get(OTEL_SCOPE);
+        if (scope != null) {
+            scope.close();
+        }
+        return true;
+    }
+
+    @Override
+    public Set<QName> getHeaders() {
+        return Collections.emptySet();
+    }
+}

--- a/tosan-soap-client/src/main/java/com/tosan/client/soap/handler/SoapHandlerResolver.java
+++ b/tosan-soap-client/src/main/java/com/tosan/client/soap/handler/SoapHandlerResolver.java
@@ -23,6 +23,13 @@ public class SoapHandlerResolver implements HandlerResolver {
         this(showLog, null, null, null);
     }
 
+    public SoapHandlerResolver(boolean showLog, Set<String> secureParameters) {
+        this.showLog = showLog;
+        this.secureParameters = secureParameters;
+        tracer = null;
+        clientName = null;
+    }
+
     public SoapHandlerResolver(boolean showLog, Set<String> secureParameters, Tracer tracer, String clientName) {
         this.showLog = showLog;
         this.secureParameters = secureParameters;
@@ -34,11 +41,13 @@ public class SoapHandlerResolver implements HandlerResolver {
     @Override
     public List<Handler> getHandlerChain(PortInfo portInfo) {
         List<Handler> handlerChain = new ArrayList<>();
+        if (tracer != null) {
+            MonitoringHandler monitoringHandler = new MonitoringHandler(tracer, clientName);
+            handlerChain.add(monitoringHandler);
+        }
         if (showLog) {
             LogHandler logHandler = new LogHandler(secureParameters);
             handlerChain.add(logHandler);
-            MonitoringHandler monitoringHandler = new MonitoringHandler(tracer, clientName);
-            handlerChain.add(monitoringHandler);
         }
         return handlerChain;
     }

--- a/tosan-soap-client/src/main/java/com/tosan/client/soap/handler/SoapHandlerResolver.java
+++ b/tosan-soap-client/src/main/java/com/tosan/client/soap/handler/SoapHandlerResolver.java
@@ -1,5 +1,6 @@
 package com.tosan.client.soap.handler;
 
+import io.opentelemetry.api.trace.Tracer;
 import jakarta.xml.ws.handler.Handler;
 import jakarta.xml.ws.handler.HandlerResolver;
 import jakarta.xml.ws.handler.PortInfo;
@@ -15,14 +16,18 @@ import java.util.Set;
 public class SoapHandlerResolver implements HandlerResolver {
     private final boolean showLog;
     private final Set<String> secureParameters;
+    private final Tracer tracer;
+    private final String clientName;
 
     public SoapHandlerResolver(boolean showLog) {
-        this(showLog, null);
+        this(showLog, null, null, null);
     }
 
-    public SoapHandlerResolver(boolean showLog, Set<String> secureParameters) {
+    public SoapHandlerResolver(boolean showLog, Set<String> secureParameters, Tracer tracer, String clientName) {
         this.showLog = showLog;
         this.secureParameters = secureParameters;
+        this.tracer = tracer;
+        this.clientName = clientName;
     }
 
     @SuppressWarnings("rawtypes")
@@ -32,6 +37,8 @@ public class SoapHandlerResolver implements HandlerResolver {
         if (showLog) {
             LogHandler logHandler = new LogHandler(secureParameters);
             handlerChain.add(logHandler);
+            MonitoringHandler monitoringHandler = new MonitoringHandler(tracer, clientName);
+            handlerChain.add(monitoringHandler);
         }
         return handlerChain;
     }


### PR DESCRIPTION
…dler.

In this implementation, tracing of outgoing requests using OpenTelemetry has been added. To enable this feature, the tracer object from the consuming project must be passed to the constructor of the SoapServiceProvider class. The sent parameters include the following attributes: -soap.operation,
-http.url,
-outcome
-client.name